### PR TITLE
Correct Spelling "condigure" -> "configure"

### DIFF
--- a/src/utils/chromadb.ts
+++ b/src/utils/chromadb.ts
@@ -8,13 +8,13 @@ export const getChromaClient = async (
   ux.action.start("Establishing connection to the Chroma server");
   if (!getConfig("HOST")) {
     command.error(
-      "No host configured for chroma server, please set CHROMA_SERVER_HOST in env or run `chromadb condigure`",
+      "No host configured for chroma server, please set CHROMA_SERVER_HOST in env or run `chromadb configure`",
     );
   }
 
   if (!getConfig("PORT")) {
     command.error(
-      "No port configured for chroma server, please set CHROMA_SERVER_PORT in env or run `chromadb condigure`",
+      "No port configured for chroma server, please set CHROMA_SERVER_PORT in env or run `chromadb configure`",
     );
   }
 

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -6,7 +6,7 @@ export const getOpenAIClient = async (command: Command): Promise<OpenAI> => {
   ux.action.start("Establishing connection to the OpenAI server");
   if (!getConfig("OPENAI_KEY")) {
     command.error(
-      "No OpenAI API Key configured for chroma server, please set CHROMA_SERVER_OPENAI_KEY in env or run `chromadb condigure`",
+      "No OpenAI API Key configured for chroma server, please set CHROMA_SERVER_OPENAI_KEY in env or run `chromadb configure`",
     );
   }
 


### PR DESCRIPTION
git diff HEAD
diff --git a/src/utils/chromadb.ts b/src/utils/chromadb.ts index bdaa141..614d174 100644
--- a/src/utils/chromadb.ts
+++ b/src/utils/chromadb.ts
@@ -8,13 +8,13 @@ export const getChromaClient = async (
   ux.action.start("Establishing connection to the Chroma server");
   if (!getConfig("HOST")) {
     command.error(
-      "No host configured for chroma server, please set CHROMA_SERVER_HOST in env or run `chromadb condigure`",
+      "No host configured for chroma server, please set CHROMA_SERVER_HOST in env or run `chromadb configure`",
     );
   }

   if (!getConfig("PORT")) {
     command.error(
-      "No port configured for chroma server, please set CHROMA_SERVER_PORT in env or run `chromadb condigure`",
+      "No port configured for chroma server, please set CHROMA_SERVER_PORT in env or run `chromadb configure`",
     );
   }

diff --git a/src/utils/openai.ts b/src/utils/openai.ts index 126d9e3..cb26840 100644
--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -6,7 +6,7 @@ export const getOpenAIClient = async (command: Command): Promise<OpenAI> => {
   ux.action.start("Establishing connection to the OpenAI server");
   if (!getConfig("OPENAI_KEY")) {
     command.error(
-      "No OpenAI API Key configured for chroma server, please set CHROMA_SERVER_OPENAI_KEY in env or run `chromadb condigure`",
+      "No OpenAI API Key configured for chroma server, please set CHROMA_SERVER_OPENAI_KEY in env or run `chromadb configure`",
     );
   }